### PR TITLE
upgrade dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@
 
 val scala210Version = "2.10.7"
 val scala211Version = "2.11.12"
-val scala212Version = "2.12.6"
+val scala212Version = "2.12.8"
 
 val attributesVersion = "0.30"
 val disciplineVersion = "0.8"


### PR DESCRIPTION
I skipped `discipline` and `scalatest` because `sbt` mentioned conflicts from `spire`.